### PR TITLE
which tap should i use for xplanet dependency

### DIFF
--- a/xplanet.rb
+++ b/xplanet.rb
@@ -3,7 +3,9 @@ class Xplanet < Formula
   homepage "https://xplanet.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xplanet/xplanet/1.3.1/xplanet-1.3.1.tar.gz"
   sha256 "4380d570a8bf27b81fb629c97a636c1673407f4ac4989ce931720078a90aece7"
-  revision 3
+  # I append '99.' to differentiate from Xplanet or any other user tap version of Xplanet.
+  # in this case, Xplanet revision is set to 2, but I have this set to 3 because this version includes the leap second fix.
+  revision 99.3
 
   option "with-x11", "Build for X11 instead of Aqua"
   option "with-all", "Build with default Xplanet configuration dependencies"

--- a/xplanetfx.rb
+++ b/xplanetfx.rb
@@ -10,21 +10,41 @@ class Xplanetfx < Formula
   option "with-xp-all", "Build to use xplanet with all default options"
   option "with-complete", "Build to use xplanet with all default options and GNU sed instead of macOS sed"
 
-  # if (File.file?(Formula["xplanet"].opt_prefix/"bin"/"xplanet"))
-  #   puts "Homebrew Xplanet is already installed so skip this tap's version."
-  #   if build.with?("xp-all") || build.with?("complete")
-  #     puts "Skipping this tap's Xplanet installation.  Uninstall Homebrew's version first."
-  #   end
-  # else
-  #   if build.with?("xp-all") || build.with?("complete")
-  #     puts "Installing default Xplanet configuration (Homebrew's default configuration is only a subset)."
-  #     depends_on "blogabe/xplanet/xplanet" => %W[ with-pango --with-netpbm --with-cspice ]
-  #   else
-  #     puts "Installing Xplanet to match Homebrew's default configuration."
-  #     depends_on "blogabe/xplanet/xplanet"
-  #   end
-  # end
-  depends_on "blogabe/xplanet/xplanet"
+  xpHomebrew=0
+  xpblogabe=0
+  if !File.exists?("#{HOMEBREW_PREFIX}/Cellar/xplanet")
+    # Xplanet is not installed.  Use this tap's version.
+    xpblogabe=1
+  else
+    # Xplanet is already installed.  Determine which version and do some error checking.
+     Dir.foreach("#{HOMEBREW_PREFIX}/Cellar/xplanet") do |xpVersion|
+      next if xpVersion == '.' or xpVersion == '..'
+      if xpVersion.include? "_99."
+        xpblogabe=1
+      else
+        xpHomebrew=1
+      end
+    end
+  end
+
+  if (xpHomebrew==1)
+    if (xpblogabe==1)
+      puts "There appear to be more than one version of Xplanet installed.  `brew uninstall` the redundant versions and retry xplanetFX installation."
+      exit
+    else
+      # Homebrew Xplanet is already installed.  Keep on using this version, but alert user.
+      puts "Looks like you're already using Homebrew's Xplanet formula.  This should not be a problem, but you may want to consider using this tap's version of Xplanet."
+      depends_on "xplanet"
+    end
+  else
+    # Use this tap's version of Xplanet.
+    if build.with?("xp-all") || build.with?("complete")
+      depends_on "blogabe/xplanet/xplanet" => %W[ with-pango --with-netpbm --with-cspice ]
+    else
+      depends_on "blogabe/xplanet/xplanet"
+    end
+  end
+
   depends_on "imagemagick"
   depends_on "wget"
   depends_on "coreutils"

--- a/xplanetfx.rb
+++ b/xplanetfx.rb
@@ -10,21 +10,21 @@ class Xplanetfx < Formula
   option "with-xp-all", "Build to use xplanet with all default options"
   option "with-complete", "Build to use xplanet with all default options and GNU sed instead of macOS sed"
 
-  if (File.file?(Formula["xplanet"].opt_prefix/"bin"/"xplanet"))
-    puts "Homebrew Xplanet is already installed so skip this tap's version."
-    if build.with?("xp-all") || build.with?("complete")
-      puts "Skipping this tap's Xplanet installation.  Uninstall Homebrew's version first."
-    end
-  else
-    if build.with?("xp-all") || build.with?("complete")
-      puts "Installing default Xplanet configuration (Homebrew's default configuration is only a subset)."
-      depends_on "blogabe/xplanet/xplanet" => %W[ with-pango --with-netpbm --with-cspice ]
-    else
-      puts "Installing Xplanet to match Homebrew's default configuration."
-      depends_on "blogabe/xplanet/xplanet"
-    end
-  end
-
+  # if (File.file?(Formula["xplanet"].opt_prefix/"bin"/"xplanet"))
+  #   puts "Homebrew Xplanet is already installed so skip this tap's version."
+  #   if build.with?("xp-all") || build.with?("complete")
+  #     puts "Skipping this tap's Xplanet installation.  Uninstall Homebrew's version first."
+  #   end
+  # else
+  #   if build.with?("xp-all") || build.with?("complete")
+  #     puts "Installing default Xplanet configuration (Homebrew's default configuration is only a subset)."
+  #     depends_on "blogabe/xplanet/xplanet" => %W[ with-pango --with-netpbm --with-cspice ]
+  #   else
+  #     puts "Installing Xplanet to match Homebrew's default configuration."
+  #     depends_on "blogabe/xplanet/xplanet"
+  #   end
+  # end
+  depends_on "blogabe/xplanet/xplanet"
   depends_on "imagemagick"
   depends_on "wget"
   depends_on "coreutils"


### PR DESCRIPTION
adds special revision in xplanet and error checking in xplanetfx to decide.  exits if there's more than 1 xplanet.  uses homebrew xplanet if that's installed.  otherwise uses this tap's version along options to pass to xplanet.