### PR TITLE
bringing over deprecated formulae

### DIFF
--- a/pygobject.rb
+++ b/pygobject.rb
@@ -1,0 +1,30 @@
+class Pygobject < Formula
+  desc "GLib/GObject/GIO Python bindings for Python 2"
+  homepage "https://wiki.gnome.org/Projects/PyGObject"
+  url "https://download.gnome.org/sources/pygobject/2.28/pygobject-2.28.7.tar.xz"
+  sha256 "bb9d25a3442ca7511385a7c01b057492095c263784ef31231ffe589d83a96a5a"
+  revision 2
+
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "python@2"
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/pygobject/2.28.7.diff"
+    sha256 "ada3da43c84410cc165d8547ad3c7809435e09c9e8539882860d97cd1ce922b2"
+  end
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--disable-introspection"
+    system "make", "install"
+    (lib/"python2.7/site-packages/pygtk.pth").append_lines <<~EOS
+      #{HOMEBREW_PREFIX}/lib/python2.7/site-packages/gtk-2.0
+    EOS
+  end
+
+  test do
+    system Formula["python@2"].opt_bin/"python2.7", "-c", "import dsextras"
+  end
+end

--- a/pygtk.rb
+++ b/pygtk.rb
@@ -1,0 +1,39 @@
+class Pygtk < Formula
+  desc "GTK+ bindings for Python"
+  homepage "http://www.pygtk.org/"
+  url "https://download.gnome.org/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2"
+  sha256 "cd1c1ea265bd63ff669e92a2d3c2a88eb26bcd9e5363e0f82c896e649f206912"
+  revision 3
+
+  depends_on "pkg-config" => :build
+  depends_on "atk"
+  depends_on "glib"
+  depends_on "gtk+"
+  depends_on "libglade"
+  depends_on "py2cairo"
+  depends_on "blogabe/xplanet/pygobject"
+
+  # Allow building with recent Pango, where some symbols were removed
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/pygtk/2.24.0.diff"
+    sha256 "ec480cff20082c41d9015bb7f7fc523c27a2c12a60772b2c55222e4ba0263dde"
+  end
+
+  def install
+    ENV.append "CFLAGS", "-ObjC"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+
+    # Fixing the pkgconfig file to find codegen, because it was moved from
+    # pygtk to pygobject. But our pkgfiles point into the cellar and in the
+    # pygtk-cellar there is no pygobject.
+    inreplace lib/"pkgconfig/pygtk-2.0.pc", "codegendir=${datadir}/pygobject/2.0/codegen", "codegendir=#{HOMEBREW_PREFIX}/share/pygobject/2.0/codegen"
+    inreplace bin/"pygtk-codegen-2.0", "exec_prefix=${prefix}", "exec_prefix=#{Formula["pygobject"].opt_prefix}"
+  end
+
+  test do
+    (testpath/"codegen.def").write("(define-enum asdf)")
+    system "#{bin}/pygtk-codegen-2.0", "codegen.def"
+  end
+end

--- a/xplanetfx.rb
+++ b/xplanetfx.rb
@@ -26,7 +26,7 @@ class Xplanetfx < Formula
 
   if build.with?("gui")
     depends_on "librsvg"
-    depends_on "pygtk"
+    depends_on "blogabe/xplanet/pygtk"
   end
 
   skip_clean "share/xplanetFX"


### PR DESCRIPTION
homebrew deleted both pygtk and pygobject due to inactivity and reliance on python 2.  bringing them here for xplanetfx